### PR TITLE
Fixes #22 (typo in transport table)

### DIFF
--- a/src/fragments/active_inventory.html
+++ b/src/fragments/active_inventory.html
@@ -980,7 +980,7 @@
 									<td>Large</td>
 									<td>60 ft</td>
 									<td>75 gp</td>
-									<td>25</td>
+									<td>28</td>
 									<td>40</td>
 								</tr>
 								<tr>
@@ -1007,7 +1007,7 @@
 									<td>Large</td>
 									<td>60 ft</td>
 									<td>400 gp</td>
-									<td>26</td>
+									<td>30</td>
 									<td>40</td>
 								</tr>
 								<tr class="divider">


### PR DESCRIPTION
Riding horses and warhorses are large and their inventory slots should be calculated as 22 + [2 * Str mod]. Previously listed values were equal to 22 + [1 * Str mod]