### PR TITLE
Add ox to table of transport animals

### DIFF
--- a/src/fragments/active_inventory.html
+++ b/src/fragments/active_inventory.html
@@ -994,6 +994,15 @@
 								</tr>
 								<tr>
 									<td></td>
+									<td>Ox</td>
+									<td>Large</td>
+									<td>30 ft</td>
+									<td>15 gp</td>
+									<td>46</td>
+									<td>40</td>
+								</tr>
+								<tr>
+									<td></td>
 									<td>Pony</td>
 									<td>Medium</td>
 									<td>40 ft</td>


### PR DESCRIPTION
Adds Ox to the table alongside other draft animals. Price based on PHB trade goods table. Other statistics (size, speed, strength modifier and Beast of burden) are based on Volo's Guide to Monsters p. 207-208.