### PR TITLE
Add table for generic dry trade goods

### DIFF
--- a/src/fragments/active_inventory.html
+++ b/src/fragments/active_inventory.html
@@ -505,6 +505,75 @@
 					</section>
 				</aside>
 
+				<h4>Trade goods</h4>
+				<p>Trade goods tend to be transported in large quantitites such as barrels, sacks, rolls or metal trade bars. When the player characters are the owners of such goods, it might also be useful to have guidance on conversions between bulk and weight.</p>
+				<p><strong>Grain</strong> include cerials and other seeds of similar size and shape. They are typically transported in sacks or barrels.</p>
+				<p><strong>Dry and powdered plants,</strong> such as flour and ground spices, have the same bulk for a certain weight. They are transported in pouches or sacks depending on their price.</p>
+				<p><strong>Textiles</strong> are often transported as rolls a yard wide.</p>
+				<p><strong>Trade bars</strong> is the more convenient format for transporting metals, regardless of the type. Their bulk is defined by weight, but they can be packed more efficiently than the equal weight in coins.</p>
+
+				<list class="panel panel--list">
+					<header class="panel__header">
+						<h4 class="panel__title">Trade goods</h4>
+					</header>
+					<section class="panel__body">
+						<table class="table table--trade-goods-dry">
+							<thead>
+								<tr>
+									<th>Trade good</th>
+									<th>Container</th>
+									<th>Amount</th>
+									<th>Bulk</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Grain</td>
+									<td>Sack</td>
+									<td>30 lb</td>
+									<td>XL,6</td>
+								</tr>
+								<tr>
+									<td>Grain</td>
+									<td>Barrel</td>
+									<td>70 lb</td>
+									<td>XXL,9</td>
+								</tr>
+								<tr>
+									<td>Flour</td>
+									<td>Sack</td>
+									<td>35 lb</td>
+									<td>XL,6</td>
+								</tr>
+								<tr>
+									<td>Spices</td>
+									<td>Pouch</td>
+									<td>2 lb</td>
+									<td>S,1</td>
+								</tr>
+								<tr>
+									<td>Textile</td>
+									<td>Roll</td>
+									<td>25-30 yd<sup>2</sup></td>
+									<td>L,3</td>
+								</tr>
+								<tr>
+									<td>Trade bar</td>
+									<td>Minor</td>
+									<td>5 lb</td>
+									<td>M,2</td>
+								</tr>
+								<tr>
+									<td>Trade bar</td>
+									<td>Major</td>
+									<td>10 lb</td>
+									<td>L,3</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+				</list>
+
 				<h2>Magical Containers</h2>
 				<p>On your adventures, you may find magical containers that can change their storage capacity far beyond the normal. For example:</p>
 


### PR DESCRIPTION
Transporting trade goods can be a very reasonable activity in Darker Dungeons, but translating between slots of goods and the value can be challenging. This was illustrated in the question at https://www.reddit.com/r/darkerdungeons5e/comments/ldztv5/trade_goods_a_question_about_bulk/. This is therefore an attempt to create conversion between bulk and the unit most likely to be used for determining the value.

The table here is based on the bulk estimation table on page 54 of the pdf of version 4.0.0. The weight became the limiting factor in all cases for determining bulk category. Volume might be more relevant for grain, flour and spices.